### PR TITLE
Update resource with new cni

### DIFF
--- a/build-calico-resource.sh
+++ b/build-calico-resource.sh
@@ -4,9 +4,9 @@ set -eux
 rm -rf resource-build
 mkdir resource-build
 cd resource-build
-wget https://github.com/projectcalico/calico-containers/releases/download/v0.23.0/calicoctl
-wget https://github.com/projectcalico/calico-cni/releases/download/v1.4.3/calico
-wget https://github.com/projectcalico/calico-cni/releases/download/v1.4.3/calico-ipam
+wget https://github.com/projectcalico/calicoctl/releases/download/v0.23.1/calicoctl
+wget https://github.com/projectcalico/cni-plugin/releases/download/v1.6.2/calico
+wget https://github.com/projectcalico/cni-plugin/releases/download/v1.6.2/calico-ipam
 chmod +x calicoctl calico calico-ipam
 tar -vcaf ../calico-resource.tar.gz .
 cd ..


### PR DESCRIPTION
@wwwtyro Update to the latest version of calico CNI plugins. We'll need this to prevent problems in Kubernetes 1.6.