### PR TITLE
update binaries

### DIFF
--- a/build-calico-resource.sh
+++ b/build-calico-resource.sh
@@ -4,9 +4,9 @@ set -eux
 rm -rf resource-build
 mkdir resource-build
 cd resource-build
-wget https://github.com/projectcalico/calicoctl/releases/download/v0.23.1/calicoctl
-wget https://github.com/projectcalico/cni-plugin/releases/download/v1.6.2/calico
-wget https://github.com/projectcalico/cni-plugin/releases/download/v1.6.2/calico-ipam
+wget https://github.com/projectcalico/calicoctl/releases/download/v1.3.0/calicoctl
+wget https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico
+wget https://github.com/projectcalico/cni-plugin/releases/download/v1.10.0/calico-ipam
 chmod +x calicoctl calico calico-ipam
 tar -vcaf ../calico-resource.tar.gz .
 cd ..

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -129,7 +129,7 @@ def configure_calico_pool(etcd):
         'nat_outgoing': 'true' if config['nat-outgoing'] else 'false'
     }
     render('pool.yaml', '/tmp/calico-pool.yaml', context)
-    cmd = '/opt/calicoctl/calicoctl create --skip-exists -f /tmp/calico-pool.yaml'
+    cmd = '/opt/calicoctl/calicoctl apply -f /tmp/calico-pool.yaml'
     check_call(cmd.split(), env=env)
     set_state('calico.pool.configured')
 

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -1,4 +1,5 @@
 import os
+from socket import gethostname
 from subprocess import check_call, CalledProcessError
 
 from charms.reactive import when, when_not, when_any, set_state, remove_state
@@ -94,6 +95,7 @@ def install_calico_service(etcd):
         'etcd_key_path': ETCD_KEY_PATH,
         'etcd_ca_path': ETCD_CA_PATH,
         'etcd_cert_path': ETCD_CERT_PATH,
+        'nodename': gethostname(),
         # specify IP so calico doesn't grab a silly one from, say, lxdbr0
         'ip': unit_private_ip()
     })
@@ -120,12 +122,14 @@ def configure_calico_pool(etcd):
     env['ETCD_KEY_FILE'] = ETCD_KEY_PATH
     env['ETCD_CERT_FILE'] = ETCD_CERT_PATH
     env['ETCD_CA_CERT_FILE'] = ETCD_CA_PATH
-    cmd = '/opt/calicoctl/calicoctl pool add ' + CALICO_CIDR
     config = hookenv.config()
-    if config['ipip']:
-        cmd += ' --ipip'
-    if config['nat-outgoing']:
-        cmd += ' --nat-outgoing'
+    context = {
+        'cidr': CALICO_CIDR,
+        'ipip': 'true' if config['ipip'] else 'false',
+        'nat_outgoing': 'true' if config['nat-outgoing'] else 'false'
+    }
+    render('pool.yaml', '/tmp/calico-pool.yaml', context)
+    cmd = '/opt/calicoctl/calicoctl create --skip-exists -f /tmp/calico-pool.yaml'
     check_call(cmd.split(), env=env)
     set_state('calico.pool.configured')
 

--- a/templates/calico-node.service
+++ b/templates/calico-node.service
@@ -1,16 +1,33 @@
 [Unit]
-Description=calicoctl node
+Description=calico node
 After=docker.service
 Requires=docker.service
 
 [Service]
 User=root
 Environment=ETCD_ENDPOINTS={{ connection_string }}
-Environment=ETCD_CA_CERT_FILE={{ etcd_ca_path }}
-Environment=ETCD_CERT_FILE={{ etcd_cert_path }}
-Environment=ETCD_KEY_FILE={{ etcd_key_path }}
 PermissionsStartOnly=true
-ExecStart=/opt/calicoctl/calicoctl node --detach=false --ip {{ ip }}
+ExecStart=/usr/bin/docker run --net=host --privileged --name=calico-node \
+  -e ETCD_ENDPOINTS={{ connection_string }} \
+  -e ETCD_CA_CERT_FILE={{ etcd_ca_path }} \
+  -e ETCD_CERT_FILE={{ etcd_cert_path }} \
+  -e ETCD_KEY_FILE={{ etcd_key_path }} \
+  -e NODENAME={{ nodename }} \
+  -e IP={{ ip }} \
+  -e NO_DEFAULT_POOLS= \
+  -e AS= \
+  -e CALICO_LIBNETWORK_ENABLED=true \
+  -e IP6= \
+  -e CALICO_NETWORKING_BACKEND=bird \
+  -e FELIX_DEFAULTENDPOINTTOHOSTACTION=ACCEPT \
+  -v /var/run/calico:/var/run/calico \
+  -v /lib/modules:/lib/modules \
+  -v /run/docker/plugins:/run/docker/plugins \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /var/log/calico:/var/log/calico \
+  -v /opt/calicoctl:/opt/calicoctl \
+  quay.io/calico/node:v1.3.0
+ExecStop=/usr/bin/docker rm -f calico-node
 Restart=always
 RestartSec=10
 

--- a/templates/policy-controller.yaml
+++ b/templates/policy-controller.yaml
@@ -1,19 +1,14 @@
-# Create this manifest using kubectl to deploy
-# the Calico policy controller on Kubernetes.
-# It deploys a single instance of the policy controller.
 apiVersion: extensions/v1beta1
-kind: ReplicaSet
+kind: Deployment
 metadata:
   name: calico-policy-controller
   namespace: kube-system
   labels:
     k8s-app: calico-policy
 spec:
-  # Only a single instance of the policy controller should be
-  # active at a time.  Since this pod is run as a ReplicaSet,
-  # Kubernetes will ensure the pod is recreated in case of failure,
-  # removing the need for passive backups.
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       name: calico-policy-controller
@@ -24,11 +19,8 @@ spec:
       hostNetwork: true
       containers:
         - name: calico-policy-controller
-          # Make sure to pin this to your desired version.
-          image: calico/kube-policy-controller:v0.4.0
+          image: quay.io/calico/kube-policy-controller:v0.6.0
           env:
-            # Configure the policy controller with the location of
-            # your etcd cluster.
             - name: ETCD_ENDPOINTS
               value: {{ connection_string }}
             - name: ETCD_CA_CERT_FILE
@@ -37,22 +29,15 @@ spec:
               value: {{ etcd_cert_path }}
             - name: ETCD_KEY_FILE
               value: {{ etcd_key_path }}
-            # Location of the Kubernetes API - this shouldn't need to be
-            # changed so long as it is used in conjunction with
-            # CONFIGURE_ETC_HOSTS="true".
             - name: K8S_API
               value: "https://kubernetes.default:443"
-            # Configure /etc/hosts within the container to resolve
-            # the kubernetes.default Service to the correct clusterIP
-            # using the environment provided by the kubelet.
-            # This removes the need for KubeDNS to resolve the Service.
             - name: CONFIGURE_ETC_HOSTS
               value: "true"
           volumeMounts:
-            # Mount for ETCD key/cert files
             - name: calicoctl
               mountPath: /opt/calicoctl
       volumes:
         - name: calicoctl
           hostPath:
             path: /opt/calicoctl
+              

--- a/templates/pool.yaml
+++ b/templates/pool.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ipPool
+metadata:
+  cidr: {{ cidr }}
+spec:
+  ipip:
+    enabled: {{ ipip }}
+    mode: always
+  nat-outgoing: {{ nat_outgoing }}


### PR DESCRIPTION
Updates the calico resource building script to pull in new binaries and the charm to use them properly. Passes dashboard, microbot, & [e2e](http://paste.ubuntu.com/25220293/).