### PR TITLE
charm support for arm64 resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ VMs, and bare metal services, that provides a rich set of security enforcement
 capabilities running on top of a highly scalable and efficient virtual network fabric.
 
 This charm will deploy calico as a background service, and configure CNI for
-use with calico, on any principal charm that implements the
-[`kubernetes-cni`](https://github.com/juju-solutions/interface-kubernetes-cni) interface.
+use with calico, on any principal charm that implements the [kubernetes-cni][]
+interface.
 
+[kubernetes-cni]: https://github.com/juju-solutions/interface-kubernetes-cni
 
 ## Usage
 
-The calico charm is a
-[subordinate](https://jujucharms.com/docs/stable/authors-subordinate-services).
-This charm will require a principal charm that implements the `kubernetes-cni`
-interface in order to properly deploy.
+The calico charm is a [subordinate][]. This charm will require a principal charm
+that implements the `kubernetes-cni` interface in order to properly deploy.
 
+[subordinate]: https://docs.jujucharms.com/2.4/en/authors-subordinate-applications
 ```
 juju deploy cs:~containers/calico
 juju deploy cs:~containers/etcd

--- a/build-calico-resource.sh
+++ b/build-calico-resource.sh
@@ -1,45 +1,50 @@
 #!/bin/bash
 set -eux
 
-# User can specify which arch resource to build as $1 (default to intel)
-arch=${1:-}
-if [ -z "$arch" ]; then
-  arch="amd64"
-fi
+# Supported calico architectures
+arches="amd64 arm64"
 
 # 2.6.x has no binary releases for arm64; fetch them from neander
 neander="ubuntu@10.96.66.14"
 
-rm -rf resource-build
-mkdir resource-build
-cd resource-build
+fetch_cni_plugins() {
+  arch=${1:-}
+  if [ -z ${arch} ]; then
+    echo "Missing arch parameter to fetch_cni_plugins"
+    exit 1
+  fi
 
-case ${arch} in
-  amd64)
+  mkdir temp
+  (cd temp
+    wget https://github.com/containernetworking/plugins/releases/download/v0.7.1/cni-plugins-${arch}-v0.7.1.tgz
+    tar -vxf cni-plugins-${arch}-v0.7.1.tgz
+    mv portmap ..
+  )
+  rm -rf temp
+}
+
+for arch in ${arches}; do
+  rm -rf resource-build-$arch
+  mkdir resource-build-$arch
+  pushd resource-build-$arch
+
+  if [ $arch = "amd64" ]; then
     wget https://github.com/projectcalico/calicoctl/releases/download/v1.6.4/calicoctl
     wget https://github.com/projectcalico/cni-plugin/releases/download/v1.11.6/calico
     wget https://github.com/projectcalico/cni-plugin/releases/download/v1.11.6/calico-ipam
-    ;;
-  arm64|aarch64)
+  elif [ $arch = "arm64" ]; then
     scp ${neander}:~/go/src/github.com/projectcalico/calicoctl/dist/calicoctl-linux-arm64 ./calicoctl
     scp ${neander}:~/go/src/github.com/projectcalico/cni-plugin/dist/calico ./calico
     scp ${neander}:~/go/src/github.com/projectcalico/cni-plugin/dist/calico-ipam ./calico-ipam
-    ;;
-  *)
-    echo "Unknown arch"
+  else
+    echo "Can't fetch binaries for $arch"
     exit 1
-    ;;
-esac
+  fi
 
-mkdir temp
-(cd temp
-  wget https://github.com/containernetworking/plugins/releases/download/v0.7.1/cni-plugins-${arch}-v0.7.1.tgz
-  tar -vxf cni-plugins-${arch}-v0.7.1.tgz
-  mv portmap ..
-)
-rm -rf temp
+  fetch_cni_plugins $arch
+  chmod +x calicoctl calico calico-ipam portmap
+  tar -vcaf ../calico-$arch.tar.gz .
 
-chmod +x calicoctl calico calico-ipam portmap
-tar -vcaf ../calico-${arch}.tar.gz .
-cd ..
-rm -rf resource-build
+  popd
+  rm -rf resource-build-$arch
+done

--- a/build-calico-resource.sh
+++ b/build-calico-resource.sh
@@ -1,22 +1,45 @@
-#!/bin/sh
+#!/bin/bash
 set -eux
+
+# User can specify which arch resource to build as $1 (default to intel)
+arch=${1:-}
+if [ -z "$arch" ]; then
+  arch="amd64"
+fi
+
+# 2.6.x has no binary releases for arm64; fetch them from neander
+neander="ubuntu@10.96.66.14"
 
 rm -rf resource-build
 mkdir resource-build
 cd resource-build
-wget https://github.com/projectcalico/calicoctl/releases/download/v1.6.4/calicoctl
-wget https://github.com/projectcalico/cni-plugin/releases/download/v1.11.6/calico
-wget https://github.com/projectcalico/cni-plugin/releases/download/v1.11.6/calico-ipam
-chmod +x calicoctl calico calico-ipam
+
+case ${arch} in
+  amd64)
+    wget https://github.com/projectcalico/calicoctl/releases/download/v1.6.4/calicoctl
+    wget https://github.com/projectcalico/cni-plugin/releases/download/v1.11.6/calico
+    wget https://github.com/projectcalico/cni-plugin/releases/download/v1.11.6/calico-ipam
+    ;;
+  arm64|aarch64)
+    scp ${neander}:~/go/src/github.com/projectcalico/calicoctl/dist/calicoctl-linux-arm64 ./calicoctl
+    scp ${neander}:~/go/src/github.com/projectcalico/cni-plugin/dist/calico ./calico
+    scp ${neander}:~/go/src/github.com/projectcalico/cni-plugin/dist/calico-ipam ./calico-ipam
+    ;;
+  *)
+    echo "Unknown arch"
+    exit 1
+    ;;
+esac
 
 mkdir temp
 (cd temp
-  wget https://github.com/containernetworking/plugins/releases/download/v0.7.1/cni-plugins-amd64-v0.7.1.tgz
-  tar -vxf cni-plugins-amd64-v0.7.1.tgz
+  wget https://github.com/containernetworking/plugins/releases/download/v0.7.1/cni-plugins-${arch}-v0.7.1.tgz
+  tar -vxf cni-plugins-${arch}-v0.7.1.tgz
   mv portmap ..
 )
 rm -rf temp
 
-tar -vcaf ../calico-resource.tar.gz .
+chmod +x calicoctl calico calico-ipam portmap
+tar -vcaf ../calico-${arch}.tar.gz .
 cd ..
 rm -rf resource-build

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,7 +22,7 @@ requires:
     interface: kubernetes-cni
     scope: container
 resources:
-  calico-amd64:
+  calico:
     type: file
     filename: calico.tar.gz
     description: 'Calico resource tarball for amd64'

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,9 +1,14 @@
 name: calico
-summary: Calico subordinate charm
+summary: A robust Software Defined Network from Project Calico
 maintainers:
-  - Rye Terrell <rye.terrell@canonical.com>
+  - Tim Van Steenburgh <tim.van.steenburgh@canonical.com>
+  - George Kraft <george.kraft@canonical.com>
+  - Konstantinos Tsakalozos <kos.tsakalozos@canonical.com>
+  - Mike Wilson <mike.wilson@canonical.com>
+  - Kevin Monroe <kevin.monroe@canonical.com>
 description: |
-  Calico subordinate charm
+  Deploys Calico as a background service and configures CNI for use with
+  calico on any principal charm that implements the kubernetes-cni interface.
 tags:
   - networking
 subordinate: true
@@ -17,7 +22,11 @@ requires:
     interface: kubernetes-cni
     scope: container
 resources:
-  calico:
+  calico-amd64:
     type: file
     filename: calico.tar.gz
-    description: 'Calico resource tarball.'
+    description: 'Calico resource tarball for amd64'
+  calico-arm64:
+    type: file
+    filename: calico.tar.gz
+    description: 'Calico resource tarball for arm64'

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -1,6 +1,6 @@
 import os
 from socket import gethostname
-from subprocess import call, check_call, CalledProcessError
+from subprocess import call, check_call, check_output, CalledProcessError
 
 from charms.reactive import when, when_not, when_any, set_state, remove_state
 from charms.reactive import hook
@@ -37,7 +37,8 @@ def upgrade_charm():
 def install_calico_binaries():
     ''' Unpack the Calico binaries. '''
     try:
-        archive = resource_get('calico')
+        resource_name = 'calico-{}'.format(arch())
+        archive = resource_get(resource_name)
     except Exception:
         message = 'Error fetching the calico resource.'
         log(message)
@@ -231,3 +232,12 @@ def deploy_network_policy_controller(etcd, cni):
 @when_any('cni.is-master', 'calico.npc.deployed')
 def ready():
     status_set('active', 'Calico is active')
+
+
+def arch():
+    '''Return the package architecture as a string.'''
+    # Get the package architecture for this system.
+    architecture = check_output(['dpkg', '--print-architecture']).rstrip()
+    # Convert the binary result into a string.
+    architecture = architecture.decode('utf-8')
+    return architecture

--- a/reactive/calico.py
+++ b/reactive/calico.py
@@ -36,8 +36,14 @@ def upgrade_charm():
 @when_not('calico.binaries.installed')
 def install_calico_binaries():
     ''' Unpack the Calico binaries. '''
+    # on intel, the resource is called 'calico'; other arches have a suffix
+    architecture = arch()
+    if architecture == "amd64":
+        resource_name = 'calico'
+    else:
+        resource_name = 'calico-{}'.format(architecture)
+
     try:
-        resource_name = 'calico-{}'.format(arch())
         archive = resource_get(resource_name)
     except Exception:
         message = 'Error fetching the calico resource.'


### PR DESCRIPTION
Add charm support for deploying on arm64.

Since we don't have binary releases of calico for arm64, we have to build them on neander and let the `build-calico-resource.sh` script fetch them from there.

Note: this only enables the *charm* to support arm64 resources. There's still the problem of creating the necessary docker images. We'll probably make our own and push to cdkbot, but that will come later. For now, operators can set appropriate config (`calico-[node|policy]-image`) if they have those images available.